### PR TITLE
Bug 1193 - fixed import and export for system datafile

### DIFF
--- a/wfe-core/src/main/java/ru/runa/wfe/script/botstation/BotConfiguration.java
+++ b/wfe-core/src/main/java/ru/runa/wfe/script/botstation/BotConfiguration.java
@@ -1,6 +1,8 @@
 package ru.runa.wfe.script.botstation;
 
 import java.io.ByteArrayOutputStream;
+import java.nio.file.FileSystems;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -68,7 +70,8 @@ public class BotConfiguration {
         // Add BotTask embedded file if exists
         if (!Strings.isNullOrEmpty(embeddedFile)) {
             task.setEmbeddedFile(context.getExternalResource(embeddedFile));
-            task.setEmbeddedFileName(embeddedFile);
+            Path path = FileSystems.getDefault().getPath(embeddedFile);
+            task.setEmbeddedFileName(path.getFileName().toString());
         }
         task.setSequentialExecution(sequentialExecution);
         byte[] conf = getConfiguration(context);

--- a/wfe-web/src/main/java/ru/runa/wf/web/datafile/builder/BotDataFileBuilder.java
+++ b/wfe-web/src/main/java/ru/runa/wf/web/datafile/builder/BotDataFileBuilder.java
@@ -40,6 +40,11 @@ public class BotDataFileBuilder implements DataFileBuilder {
                     }                    
                     zos.putNextEntry(new ZipEntry(PATH_TO_BOTTASK + getConfigurationName(botTask) + ".conf"));                                       
                     zos.write(conf);
+                    byte[] embeddedFile = botTask.getEmbeddedFile();
+                    if (embeddedFile != null && StringUtils.isNotEmpty(botTask.getEmbeddedFileName())) {
+                        zos.putNextEntry(new ZipEntry(PATH_TO_BOTTASK + botTask.getEmbeddedFileName()));
+                        zos.write(embeddedFile);
+                    }
                 }
             }
         }
@@ -80,6 +85,9 @@ public class BotDataFileBuilder implements DataFileBuilder {
         }
         if (StringUtils.isNotEmpty(botTask.getName())) {
             subElement.addAttribute(AdminScriptConstants.NAME_ATTRIBUTE_NAME, botTask.getName());
+        }
+        if (StringUtils.isNotEmpty(botTask.getEmbeddedFileName())) {
+            subElement.addAttribute(AdminScriptConstants.EMBEDDED_FILE_ATTRIBUTE_NAME, PATH_TO_BOTTASK + botTask.getEmbeddedFileName());
         }
         if (botTask.getConfiguration() != null && botTask.getConfiguration().length > 0) {           
             subElement.addAttribute(AdminScriptConstants.CONFIGURATION_STRING_ATTRIBUTE_NAME, getConfigurationName(botTask) + ".conf");


### PR DESCRIPTION
Fixed import and export for system datafile containing embedded file in botConfiguration section.

Embedded file placed in scripts/ directory of archive datafile. Then during import it only saves base file name of embedded file omiting scripts/ .